### PR TITLE
Validate phone numbers and postcodes

### DIFF
--- a/apps/common/fields/contact-details.js
+++ b/apps/common/fields/contact-details.js
@@ -15,6 +15,7 @@ module.exports = {
     label: 'fields.no-email.label'
   },
   phone: {
+    validate: ['phonenumber'],
     label: 'fields.phone.label'
   },
   'contact-address-house-number': {

--- a/apps/common/fields/organisation-details.js
+++ b/apps/common/fields/organisation-details.js
@@ -93,7 +93,7 @@ module.exports = {
     label: 'fields.org-address-county.label',
   },
   'org-address-postcode': {
-    validate: ['required'],
+    validate: ['required', 'postcode'],
     label: 'fields.org-address-postcode.label'
   }
 };

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -31,6 +31,7 @@
     "required": "Enter the town or city"
   },
   "org-address-postcode": {
-    "required": "Enter the postcode"
+    "required": "Enter the postcode",
+    "postcode": "Enter your postcode in the correct format, for example SW1A 1AA"
   }
 }

--- a/apps/contact-ukti/controllers/company-address.js
+++ b/apps/contact-ukti/controllers/company-address.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var util = require('util');
+var BaseController = require('hof').controllers.base;
+
+var CompanyAddressController = function CompanyAddressController() {
+  BaseController.apply(this, arguments);
+};
+
+util.inherits(CompanyAddressController, BaseController);
+
+CompanyAddressController.prototype.validateField = function validateField(key, req) {
+  if (key === 'org-address-postcode' &&
+      req.body['org-address-postcode'] !== '' &&
+      req.sessionModel.get('inside-uk') === 'no') {
+    return undefined;
+  }
+
+  return BaseController.prototype.validateField.apply(this, arguments);
+};
+
+module.exports = CompanyAddressController;

--- a/apps/contact-ukti/steps.js
+++ b/apps/contact-ukti/steps.js
@@ -54,6 +54,7 @@ module.exports = {
     next: '/company-address',
   },
   '/company-address': {
+    controller: require('./controllers/company-address'),
     fields: [
       'org-address-house-number',
       'org-address-street',

--- a/apps/contact-ukti/translations/src/en/validation.json
+++ b/apps/contact-ukti/translations/src/en/validation.json
@@ -12,6 +12,9 @@
     "required": "Enter your email address",
     "email": "Enter your email in the correct format, for example name@domain.com"
   },
+  "phone": {
+    "phonenumber": "Enter your phone number in the correct format, for example 020 7946 0937 or 07700 900579"
+  },
   "inside-uk": {
     "required": "Tell us where you are"
   },

--- a/test/unit/apps/contact-ukti/controllers/company-address.js
+++ b/test/unit/apps/contact-ukti/controllers/company-address.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var Controller = sinon.stub();
+
+var CompanyAddressController = proxyquire('../../../../../apps/contact-ukti/controllers/company-address', {
+  'hof': {
+    controllers: {
+      base: Controller
+    }
+  }
+});
+
+describe('apps/contact-ukti/controllers/company-address', function () {
+
+  describe('when outside of the uk', function () {
+
+    var controller;
+    var key = 'org-address-postcode';
+    var req = {
+      body: {
+        'org-address-postcode': 'INTERNATIONAL POSTCODE'
+      },
+      sessionModel: {
+        get: function () {
+          return 'no';
+        }
+      },
+    };
+
+    beforeEach(function () {
+      controller = new CompanyAddressController({template: 'index'});
+    });
+
+    it('does not validate address postcode', function () {
+      should.equal(controller.validateField(key, req), undefined);
+    });
+
+  });
+
+  describe('when inside of the uk', function () {
+
+    var controller;
+    var key = 'org-address-postcode';
+    var req = {
+      body: {
+        'org-address-postcode': 'INTERNATIONAL POSTCODE'
+      },
+      sessionModel: {
+        get: function () {
+          return 'yes';
+        }
+      },
+    };
+
+    beforeEach(function () {
+      Controller.prototype.validateField = sinon.stub();
+      controller = new CompanyAddressController({template: 'index'});
+    });
+
+    it('does validate address postcode', function () {
+      controller.validateField(key, req);
+      Controller.prototype.validateField.should.have.been.calledWith(key, req);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds further validation to specific input types:

- Phone numbers
- Postcodes (these are used to send the enquiry to the correct location so are required)