### PR TITLE
Add feedback link via email address

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@ app.use(function setBaseUrl(req, res, next) {
 
 // pass tracking id to template
 app.locals.trackingId = config.trackingId;
+app.locals.feedbackEmail = config.feedbackEmail;
 
 /*************************************/
 /******* Redis session storage *******/

--- a/apps/common/views/layout.html
+++ b/apps/common/views/layout.html
@@ -16,7 +16,7 @@
     <div class="phase-banner">
       <p>
         <strong class="phase-tag">ALPHA</strong>
-        <span>This is a new service – your <a href="mailto:">feedback</a> will help us to improve it.</span>
+        <span>This is a new service{{#feedbackEmail}} – your <a href="mailto:{{ feedbackEmail }}?subject=Contact Form Feedback">feedback</a> will help us to improve it{{/feedbackEmail}}.</span>
       </p>
     </div>
     <span class="steps">

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ module.exports = {
   port: process.env.PORT || 8080,
   listen_host: process.env.LISTEN_HOST || '0.0.0.0',
   trackingId: process.env.TRACKING_ID,
+  feedbackEmail: process.env.FEEDBACK_EMAIL_ADDRESS,
   postcodeApi: process.env.POSTCODE_API || 'http://api.postcodes.io/postcodes',
   auth: {
     use: process.env.USE_AUTH,


### PR DESCRIPTION
Add initial method for capturing feedback. 

- Use a `mailto` link to trigger the users email client. 
- Store email address as environment variable