### PR TITLE
Update path of contact us app to sit at site root

### DIFF
--- a/apps/common/controllers/confirm.js
+++ b/apps/common/controllers/confirm.js
@@ -15,7 +15,7 @@ var ConfirmController = function ConfirmController() {
 util.inherits(ConfirmController, BaseController);
 
 var serviceMap = {
-  '/contact-ukti/confirm': function notArrived() {
+  '/confirm': function contactUkti() {
     return {
       template: 'contact-ukti',
       subject: 'Form submitted: Contact UK Trade & Investment'

--- a/apps/contact-ukti/index.js
+++ b/apps/contact-ukti/index.js
@@ -19,7 +19,7 @@ router.use(mixins(fields, {
   translate: i18n.translate.bind(i18n)
 }));
 
-router.use('/contact-ukti/', wizard(require('./steps'), fields, {
+router.use('/', wizard(require('./steps'), fields, {
   controller: require('hof').controllers.base,
   templatePath: path.resolve(__dirname, 'views'),
   translate: i18n.translate.bind(i18n),

--- a/test/acceptance/features/pages/company-address.js
+++ b/test/acceptance/features/pages/company-address.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/company-address';
+  var url = '/company-address';
   var fields = {
     orgAddressHouseNumber: {
       selector: '#org-address-house-number',

--- a/test/acceptance/features/pages/company-details.js
+++ b/test/acceptance/features/pages/company-details.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/company-details';
+  var url = '/company-details';
   var fields = {
     orgName: {
       selector: '#org-name',

--- a/test/acceptance/features/pages/company-location.js
+++ b/test/acceptance/features/pages/company-location.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/company-location';
+  var url = '/company-location';
   var fields = {
     insideUk: {
       selector: '[name="inside-uk"]',

--- a/test/acceptance/features/pages/confirm.js
+++ b/test/acceptance/features/pages/confirm.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/confirm';
+  var url = '/confirm';
   var $form = 'form';
 
   /**

--- a/test/acceptance/features/pages/enquiry-reason.js
+++ b/test/acceptance/features/pages/enquiry-reason.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/enquiry-reason';
+  var url = '/enquiry-reason';
   var fields = {
     reason: {
       selector: '[name="enquiry-reason"]',

--- a/test/acceptance/features/pages/enquiry.js
+++ b/test/acceptance/features/pages/enquiry.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/enquiry';
+  var url = '/enquiry';
   var fields = {
     enquiryDescription: {
       selector: '#enquiry-description',

--- a/test/acceptance/features/pages/exported-before.js
+++ b/test/acceptance/features/pages/exported-before.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/previously-sold-overseas';
+  var url = '/previously-sold-overseas';
   var fields = {
     exportedBefore: {
       selector: '[name="exported-before"]',

--- a/test/acceptance/features/pages/industry.js
+++ b/test/acceptance/features/pages/industry.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/operating-industry';
+  var url = '/operating-industry';
   var fields = {
     sector: {
       selector: '#sector',

--- a/test/acceptance/features/pages/personal-details.js
+++ b/test/acceptance/features/pages/personal-details.js
@@ -12,7 +12,7 @@ var Page = function Page(client) {
    * Private
    */
 
-  var url = '/contact-ukti/personal-details';
+  var url = '/personal-details';
   var fields = {
     fullname: {
       selector: '#fullname',

--- a/test/unit/apps/common/controllers/confirm.js
+++ b/test/unit/apps/common/controllers/confirm.js
@@ -27,7 +27,7 @@ describe('apps/common/controllers/confirm', function () {
       sessionModel: {
         toJSON: sinon.stub().returns(expected)
       },
-      originalUrl: '/contact-ukti/confirm'
+      originalUrl: '/confirm'
     };
     var res = {};
     var callback = sinon.stub();
@@ -43,7 +43,7 @@ describe('apps/common/controllers/confirm', function () {
     });
 
     it('sets a template for contact ukti journey', function () {
-      req.originalUrl = '/contact-ukti/confirm';
+      req.originalUrl = '/confirm';
       controller.saveValues(req, res, callback);
 
       modelProto.set.should.have.been.calledWith('template', 'contact-ukti');


### PR DESCRIPTION
The contact us sub app currently sits at `/contact-utki/`. This means that visiting the root will give you a 404. 

As this application currently only has one sub app it should sit at the site root instead `/`. 