### PR TITLE
Replace connect-memcached with one that supports authentication

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ var logger = require('./lib/logger');
 var auth = require('./lib/basic-auth');
 var churchill = require('churchill');
 var session = require('express-session');
-var MemcachedStore = require('connect-memcached')(session);
+var MemcachedStore = require('connect-memjs')(session);
 var config = require('./config');
 require('moment-business');
 
@@ -52,7 +52,9 @@ app.locals.feedbackEmail = config.feedbackEmail;
 /*************************************/
 
 var memcachedStore = new MemcachedStore({
-  hosts: config.memcached.hosts,
+  servers: [config.memcached.hosts],
+  username: config.memcached.username,
+  password: config.memcached.password,
 });
 
 function secureCookies(req, res, next) {

--- a/config.js
+++ b/config.js
@@ -20,7 +20,9 @@ module.exports = {
     ttl: process.env.SESSION_TTL || (30 * 60 * 1000) /* 30 mins timeout */
   },
   memcached: {
-    hosts: process.env.MEMCACHEDCLOUD_SERVERS || 'localhost:11211'
+    hosts: process.env.MEMCACHEDCLOUD_SERVERS || 'localhost:11211',
+    username: process.env.MEMCACHEDCLOUD_USERNAME,
+    password: process.env.MEMCACHEDCLOUD_PASSWORD
   },
   email: {
     caseworker: {

--- a/documentation/ENVIRONMENT_VARIABLES.md
+++ b/documentation/ENVIRONMENT_VARIABLES.md
@@ -9,7 +9,9 @@
 * `AUTH_PASS` password for authentication. No default.
 * `SESSION_SECRET` session secret.
 * `SESSION_TTL` number of seconds before session expires.
-* `MEMCACHEDCLOUD_SERVERS` memcached server locations. Defaults to 'localhost:11211'.
+* `MEMCACHEDCLOUD_SERVERS` Memcached Cloud server locations. Should be comma separated string. Defaults to 'localhost:11211'.
+* `MEMCACHEDCLOUD_USERNAME` Memcached Cloud username. No default.
+* `MEMCACHEDCLOUD_PASSWORD` Memcached Cloud password. No default.
 * `LISTEN_HOST` the host to listen on. Defaults to '0.0.0.0'.
 * `WDIO_BASEURL` base URL for webdriver to use for acceptance tests. No default.
 * `NODE_ENV` the application will log with lots of debug when it's set to 'development'. No default.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "body-parser": "^1.13.0",
     "browserify": "^12.0.1",
     "churchill": "0.0.5",
-    "connect-memcached": "^0.1.0",
+    "connect-memjs": "0.0.8",
     "cookie-parser": "^1.3.5",
     "email-templates": "^2.0.1",
     "express": "^4.12.4",


### PR DESCRIPTION
[Heroku uses](https://devcenter.heroku.com/articles/memcachedcloud#using-memcached-from-node-js) SASL for Memcached instances which [connect-memcached](https://github.com/balor/connect-memcached) doesn't support. Therefore we need to swap it for [connect-memjs](https://github.com/liamdon/connect-memjs).