### PR TITLE
Use fallback email address if postcode cannot be found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
     - node_modules
 
 before_script:
-  - NODE_ENV='ci' npm start&
+  - NODE_ENV='ci' LOG_LEVEL='info' npm start&
 
 script:
   - npm run test

--- a/config.js
+++ b/config.js
@@ -18,6 +18,7 @@ module.exports = {
     // 30 mins timeout
     ttl: process.env.SESSION_TTL || (30 * 60 * 1000)
   },
+  logLevel: process.env.LOG_LEVEL || 'warn',
   sentry: {
     dsn: process.env.SENTRY_DSN
   },

--- a/documentation/ENVIRONMENT_VARIABLES.md
+++ b/documentation/ENVIRONMENT_VARIABLES.md
@@ -1,6 +1,8 @@
 ## Environment Variables
 
+* `NODE_ENV` the application will log with lots of debug when it's set to 'development'. No default.
 * `PORT` server port. Defaults to 8080.
+* `LISTEN_HOST` the host to listen on. Defaults to '0.0.0.0'.
 * `TRACKING_ID` analytics tracking id. No default.
 * `FEEDBACK_EMAIL_ADDRESS` email address for service feedback. No default.
 * `POSTCODE_API` API endpoint for postcode server. Defaults to 'http://api.postcodes.io/postcodes'.
@@ -9,13 +11,12 @@
 * `AUTH_PASS` password for authentication. No default.
 * `SESSION_SECRET` session secret.
 * `SESSION_TTL` number of seconds before session expires.
+* `LOG_LEVEL` Level of logging to user. Defaults to 'warn'.
 * `SENTRY_DSN` data source name for [Sentry](https://getsentry.com). No default
 * `MEMCACHEDCLOUD_SERVERS` Memcached Cloud server locations. Should be comma separated string. Defaults to 'localhost:11211'.
 * `MEMCACHEDCLOUD_USERNAME` Memcached Cloud username. No default.
 * `MEMCACHEDCLOUD_PASSWORD` Memcached Cloud password. No default.
-* `LISTEN_HOST` the host to listen on. Defaults to '0.0.0.0'.
 * `WDIO_BASEURL` base URL for webdriver to use for acceptance tests. No default.
-* `NODE_ENV` the application will log with lots of debug when it's set to 'development'. No default.
 
 ### Email service environment variables
 (Will be removed from the app when the email service is created)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,8 +7,11 @@ var exceptionTransports = [];
 var isProd = config.env === 'production';
 var logLevel = 'warn';
 
-if (!isProd && config.env !== 'test') {
+if (!isProd) {
   logLevel = 'silly';
+}
+if (config.env === 'test' || config.env === 'ci') {
+  logLevel = 'silent';
 }
 
 loggingTransports.push(

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,48 +4,34 @@ var winston = require('winston');
 var config = require('../config');
 var loggingTransports = [];
 var exceptionTransports = [];
-var isProd = config.env === 'production';
-var logLevel = 'warn';
-
-if (!isProd) {
-  logLevel = 'silly';
-}
-if (config.env === 'test' || config.env === 'ci') {
-  logLevel = 'silent';
-}
 
 loggingTransports.push(
   new (winston.transports.Console)({
-    level: logLevel,
-    json: isProd ? true : false,
+    level: config.logLevel,
+    json: false,
     timestamp: true,
-    colorize: true,
-    stringify: function stringify(obj) {
-      return JSON.stringify(obj);
-    }
+    colorize: true
   })
 );
 
-exceptionTransports.push(
-  new (winston.transports.Console)({
-    json: true,
-    timestamp: true,
-    colorize: false,
-    stringify: function stringify(obj) {
-      return JSON.stringify(obj);
-    }
-  })
-);
+if (config.env === 'production') {
+  exceptionTransports.push(
+    new (winston.transports.Console)({
+      json: true,
+      timestamp: true,
+      colorize: false,
+      stringify: function stringify(obj) {
+        return JSON.stringify(obj);
+      }
+    })
+  );
+}
 
 var winstonConfig = {
   transports: loggingTransports,
   exceptionHandlers: exceptionTransports,
   exitOnError: true
 };
-
-if (!isProd) {
-  delete winstonConfig.exceptionHandlers;
-}
 
 var logger = new (winston.Logger)(winstonConfig);
 logger.cli();

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint .",
     "style": "jscs **/*.js --config=./.jscsrc.json",
     "test": "npm run lint & npm run style & npm run test:unit",
-    "test:unit": "NODE_ENV=test istanbul test _mocha -- --opts ./test/unit/mocha.opts -R spec",
+    "test:unit": "NODE_ENV=test LOG_LEVEL=silent istanbul test _mocha -- --opts ./test/unit/mocha.opts -R spec",
     "test:acceptance": "wdio test/acceptance/wdio.conf.js",
     "test:acceptance-wip": "wdio test/acceptance/wdio.wip.conf.js",
     "test:acceptance-headless": "wdio test/acceptance/wdio.headless.conf.js",

--- a/test/unit/services/email/index.js
+++ b/test/unit/services/email/index.js
@@ -30,7 +30,7 @@ describe('Email service', function() {
       });
     });
 
-    it('should fail to get an email address', function(done) {
+    it('should get a fallback email address', function(done) {
       nock(config.postcodeApi)
         .get('/AAA')
         .reply(404, {
@@ -44,7 +44,7 @@ describe('Email service', function() {
         };
 
         emailService.send(emailFixture, function(error) {
-          error.should.be.an.instanceof(Error);
+          should.not.exist(error);
           done();
         });
       });
@@ -117,7 +117,7 @@ describe('Email service', function() {
       });
     });
 
-    it('should return an error if region lookup fails', function() {
+    it('hould return default email address if region lookup fails', function() {
       var postcode = 'AAA';
       var reason = i18n.translate('fields.enquiry-reason.options.export.label');
       nock(config.postcodeApi)
@@ -126,8 +126,8 @@ describe('Email service', function() {
           status: 404
         });
 
-      return emailService.getCaseworkerEmail(reason, postcode, function(error) {
-        error.should.be.an.instanceof(Error);
+      return emailService.getCaseworkerEmail(reason, postcode, function(e, result) {
+        result.should.equal(config.email.caseworker.default);
       });
     });
   });


### PR DESCRIPTION
This solves a problem where the form would give a generic server error if the postcode was not valid.

Now, it will fallback to the general email address but log an error in sentry.