### PR TITLE
Format spaces out of phone number so it passes validation

### DIFF
--- a/apps/common/fields/contact-details.js
+++ b/apps/common/fields/contact-details.js
@@ -13,6 +13,7 @@ module.exports = {
     className: 'inline',
   },
   phone: {
+    formatter: ['removespaces'],
     validate: ['phonenumber'],
   },
 };


### PR DESCRIPTION
This fixes a bug where valid phone number inputs are coming back invalid. Mostly when they contain spaces. 

A discussion on changing the validator is being had on the [library](https://github.com/UKHomeOffice/passports-form-controller/issues/33) that provides validation but this is one current fix for this issue. 

The downside is it goes against [GDS guidance](https://designpatterns.hackpad.com/Phone-numbers-9Gnnfam9Aqr#:h=Play-back-phone-numbers-in-the) on replaying phone numbers in the format users entered them. 