### PR TITLE
BCC admin email address and set reply-to header

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,6 +29,7 @@ module.exports = {
   },
   email: {
     caseworker: {
+      blindCopy: process.env.CASEWORKER_BCC_EMAIL,
       default: process.env.CASEWORKER_DEFAULT_EMAIL || 'enquiries@ukti.gsi.gov.uk',
       investment: process.env.CASEWORKER_INVESTMENT_EMAIL || 'enquiries@ukti-invest.com',
       bizops: process.env.CASEWORKER_BIZOPS_EMAIL || 'bizoppteam@ukti.gov.uk',
@@ -41,7 +42,7 @@ module.exports = {
       user: process.env.SMTP_USER || '',
       pass: process.env.SMTP_PASSWORD || ''
     },
-    from: process.env.FROM_ADDRESS || 'UKTI <info@ukti.gov.uk>'
+    from: process.env.FROM_ADDRESS || 'UK Trade & Investment <no-reply@contactus.ukti.gov.uk>'
   },
   // webdriverio
   webdriver: {

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -77,6 +77,8 @@ Emailer.prototype = {
           batch.push({
             template: new EmailTemplate(path.join(templatesDir, email.template, 'caseworker')),
             to: caseworkerEmail,
+            bcc: config.email.caseworker.blindCopy,
+            replyTo: email.to || null,
             subject: email.subject,
             locals: templateLocals
           });
@@ -105,7 +107,9 @@ Emailer.prototype = {
 
       this.transporter.sendMail({
         from: config.email.from,
+        replyTo: item.replyTo || config.email.from,
         to: item.to,
+        bcc: item.bcc,
         subject: item.subject,
         html: results.html,
         text: results.text,


### PR DESCRIPTION
This adds a BCC option to blind copy an admin email address on all emails. 

It also adds the ability to set a reply-to header so the reply address can be the sender of the email.