### PR TITLE
Handle no cookies error to avoid redirect loop

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,6 +117,9 @@ app.use(session({
   saveUninitialized: true
 }));
 
+// use the hof middleware
+app.use(require('hof').middleware());
+
 // redirect base root to enquiry app
 app.get('/', function rootRedirect(req, res) {
   res.redirect('/enquiry');

--- a/apps/common/translations/src/en/errors.json
+++ b/apps/common/translations/src/en/errors.json
@@ -10,5 +10,9 @@
   "not-found": {
     "title": "Page not found",
     "message": "If you entered a web address please check it was correct."
+  },
+  "cookies-required": {
+    "title": "Cookies are required to use this service",
+    "message": "Cookies are required in order to use the BRP service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."
   }
 }

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -13,7 +13,7 @@
 {{/header}}
 
 {{$content}}
-    <p>{{content.message}}</p>
+    <p>{{{content.message}}}</p>
     <a href="/{{startLink}}" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>

--- a/errors/index.js
+++ b/errors/index.js
@@ -17,6 +17,14 @@ module.exports = function errorHandler(err, req, res, next) {
     content.message = i18n.translate('errors.session.message');
   }
 
+  console.log(err.code);
+
+  if (err.code === 'NO_COOKIES') {
+    err.status = 403;
+    content.title = i18n.translate('errors.cookies-required.title');
+    content.message = i18n.translate('errors.cookies-required.message');
+  }
+
   err.template = 'error';
   content.title = content.title || i18n.translate('errors.default.title');
   content.message = content.message || i18n.translate('errors.default.message');

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.13.0",
     "git-rev-sync": "^1.4.0",
-    "hof": "^3.1.0",
+    "hof": "^5.0.0",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "jade": "^1.11.0",


### PR DESCRIPTION
This solves a problem that causes a redirect loop when cookies are not set by the user. 

Uses HOF middleware to handle the error and then catch the error on the application side. 