### PR TITLE
Track release in sentry errors as git sha

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,17 +5,19 @@ var app = express();
 var path = require('path');
 var logger = require('./lib/logger');
 var auth = require('./lib/basic-auth');
+var config = require('./config');
 var churchill = require('churchill');
+var git = require('git-rev-sync');
 var raven = require('raven');
+var ravenClient = new raven.Client(config.sentry.dsn, {release: git.long()});
 var session = require('express-session');
 var url = require('url');
 var redis = require('redis');
 var RedisStore = require('connect-redis-crypto')(session);
-var config = require('./config');
 require('moment-business');
 
 // sentry error monitoring
-app.use(raven.middleware.express.requestHandler(config.sentry.dsn));
+app.use(raven.middleware.express.requestHandler(ravenClient));
 
 /*************************************/
 /* Force Https                       */
@@ -145,7 +147,7 @@ app.get('/contactSearch.html', redirectOfficeFinder);
 app.get('/doContactRegionSearch.html', redirectOfficeFinder);
 
 // errors
-app.use(raven.middleware.express.errorHandler(config.sentry.dsn));
+app.use(raven.middleware.express.errorHandler(ravenClient));
 app.use(require('./errors/page-not-found'));
 app.use(require('./errors/'));
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^4.13.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.13.0",
+    "git-rev-sync": "^1.4.0",
     "hof": "^3.1.0",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",


### PR DESCRIPTION
This adds the current git commit sha to the raven client so issues can be related to a particular release.