### PR TITLE
Remove link from proposition header

### DIFF
--- a/apps/common/views/partials/navigation.html
+++ b/apps/common/views/partials/navigation.html
@@ -1,6 +1,5 @@
 <div class="header-proposition">
   <div class="content">
-    <a href="{{baseUrl}}" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}
-    </a>
+    <span id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</span>
   </div>
 </div>


### PR DESCRIPTION
Currently clicking the link takes the user to the start step which
resets the session.