### PR TITLE
Capture sector after submissions

### DIFF
--- a/apps/common/controllers/confirm.js
+++ b/apps/common/controllers/confirm.js
@@ -68,6 +68,14 @@ ConfirmController.prototype.saveValues = function saveValues(req, res, callback)
         },
       ];
 
+      if (data.sector) {
+        events.push({
+          category: 'Sector',
+          action: 'standard',
+          label: data.sector
+        });
+      }
+
       async.each(events, function eachEvent(params, next) {
         analytics.event(params, next);
       }, callback);


### PR DESCRIPTION
Capturing the the sector allows metrics to be built up around
which industries enquiries are coming from