### PR TITLE
Wait for next page for back step definition

### DIFF
--- a/test/acceptance/features/steps/shared.js
+++ b/test/acceptance/features/steps/shared.js
@@ -56,7 +56,8 @@ var sharedSteps = function sharedSteps() {
    */
   this.When(/^I go back a step$/, function submitForm() {
     return browser
-      .click('=Back');
+      .click('=Back')
+      .waitForExist('body');
   });
 
   /**


### PR DESCRIPTION
Currently the next page has not been loaded when this step is seen as complete which means that when checking for things on the next page they are not present. 

This waits for the body on the following page before proceeding. 